### PR TITLE
Added skip of generated field for mysql

### DIFF
--- a/modules/anonymizers/mysql/dh.go
+++ b/modules/anonymizers/mysql/dh.go
@@ -24,6 +24,14 @@ func dhCreateTableFieldName(usrCtx any, deferred, token []byte) ([]byte, error) 
 	return append(deferred, token...), nil
 }
 
+func dhPopTableLastFieldName(usrCtx any, deferred, token []byte) ([]byte, error) {
+
+	filter := usrCtx.(*relfilter.Filter)
+	filter.ColumnPop()
+
+	return append(deferred, token...), nil
+}
+
 func dhInsertIntoTableName(usrCtx any, deferred, token []byte) ([]byte, error) {
 
 	filter := usrCtx.(*relfilter.Filter)

--- a/modules/anonymizers/mysql/mysql.go
+++ b/modules/anonymizers/mysql/mysql.go
@@ -116,8 +116,43 @@ func Init(ctx context.Context, r io.Reader, rules relfilter.Rules) io.Reader {
 						},
 					},
 				},
+				stateFieldsGenerated: {
+					NextStates: []fsm.NextState{
+						{
+							Name: stateFieldsDescriptionBlock,
+							Switch: fsm.Switch{
+								Trigger: []byte(","),
+								Delimiters: fsm.Delimiters{
+									R: []byte{'\n'},
+								},
+							},
+							DataHandler: nil,
+						},
+						{
+							Name: statefFieldsDescriptionBlockEnd,
+							Switch: fsm.Switch{
+								Trigger: []byte(")"),
+								Delimiters: fsm.Delimiters{
+									L: []byte{'\n'},
+								},
+							},
+							DataHandler: nil,
+						},
+					},
+				},
 				stateFieldsDescriptionNameTail: {
 					NextStates: []fsm.NextState{
+						{
+							Name: stateFieldsGenerated,
+							Switch: fsm.Switch{
+								Trigger: []byte("GENERATED"),
+								Delimiters: fsm.Delimiters{
+									L: []byte{' '},
+									R: []byte{' '},
+								},
+							},
+							DataHandler: dhPopTableLastFieldName,
+						},
 						{
 							Name: stateFieldsDescriptionBlock,
 							Switch: fsm.Switch{

--- a/modules/anonymizers/mysql/states.go
+++ b/modules/anonymizers/mysql/states.go
@@ -23,4 +23,5 @@ var (
 	stateTableValuesEnd             = fsm.StateName("table values end")
 	stateTableValuesStringEnd       = fsm.StateName("table values string end")
 	stateValuesSearchKeyword        = fsm.StateName("values search key VALUES")
+	stateFieldsGenerated            = fsm.StateName("fields generated search")
 )

--- a/modules/filters/relfilter/filter.go
+++ b/modules/filters/relfilter/filter.go
@@ -34,10 +34,11 @@ type Row struct {
 }
 
 type tableData struct {
-	name    string
-	columns map[string]int
-	values  []rowValue
-	uniques map[string]map[string]any
+	name           string
+	columns        map[string]int
+	columnsOrdered []string
+	values         []rowValue
+	uniques        map[string]map[string]any
 }
 
 type rowValue struct {
@@ -56,10 +57,11 @@ func Init(rules Rules) *Filter {
 // TableCreate creates new data set for table `name`
 func (filter *Filter) TableCreate(name string) {
 	filter.tableData = tableData{
-		name:    name,
-		columns: make(map[string]int),
-		uniques: make(map[string]map[string]any),
-		values:  []rowValue{},
+		name:           name,
+		columns:        make(map[string]int),
+		columnsOrdered: make([]string, 0),
+		uniques:        make(map[string]map[string]any),
+		values:         []rowValue{},
 	}
 }
 
@@ -70,6 +72,18 @@ func (filter *Filter) TableNameGet() string {
 // ColumnAdd adds new column into current data set
 func (filter *Filter) ColumnAdd(name string) {
 	filter.tableData.columns[name] = len(filter.tableData.columns)
+	filter.tableData.columnsOrdered = append(filter.tableData.columnsOrdered, name)
+}
+
+func (filter *Filter) ColumnPop() {
+	lastColumnIdx := len(filter.tableData.columnsOrdered) - 1
+	if lastColumnIdx < 0 {
+		return
+	}
+
+	lastColumn := filter.tableData.columnsOrdered[lastColumnIdx]
+	delete(filter.tableData.columns, lastColumn)
+	filter.tableData.columnsOrdered = filter.tableData.columnsOrdered[:lastColumnIdx]
 }
 
 func (filter *Filter) ValueByteAdd(b []byte) {


### PR DESCRIPTION
```sql
-- Create the table
CREATE TABLE `my_table` (
      `id` INT PRIMARY KEY,
      `first_name` VARCHAR(50),
      `last_name` VARCHAR(50),
      `full_name` VARCHAR(100) GENERATED ALWAYS AS (CONCAT(first_name, ' ', last_name)) STORED
);

-- Insert two records
INSERT INTO `my_table` (id, first_name, last_name) VALUES (1, 'John', 'Doe'), (2, 'Jane', 'Smith');
```

```yml
filters:
  my_table:
    columns:
      first_name:
        value: "{{- randAlphaNum 20 | nospace -}}"
```