### PR TITLE
added option to skip template if column value is NULL

### DIFF
--- a/ctx/conf.go
+++ b/ctx/conf.go
@@ -18,8 +18,9 @@ type filterConf struct {
 }
 
 type columnFilterConf struct {
-	Value  string `conf:"value"`
-	Unique bool   `conf:"unique"`
+	Value    string `conf:"value"`
+	Unique   bool   `conf:"unique"`
+	AutoNULL bool   `conf:"autonull"`
 }
 
 type mysqlConf struct {

--- a/ctx/context.go
+++ b/ctx/context.go
@@ -60,8 +60,9 @@ func (c *Ctx) Init(opts appctx.CustomContextFuncOpts) (appctx.CfgData, error) {
 				cc := make(map[string]relfilter.ColumnRule)
 				for c, cf := range f.Columns {
 					cc[c] = relfilter.ColumnRule{
-						Value:  cf.Value,
-						Unique: cf.Unique,
+						Value:    cf.Value,
+						Unique:   cf.Unique,
+						AutoNULL: cf.AutoNULL,
 					}
 				}
 				return cc


### PR DESCRIPTION
Suggest option `autonull`

```
filters:
  my_table:
    columns:
      last_name:
        value: "{{- randAlphaNum 20 | nospace -}}"
        autonull: true
```

if autonull is true than
  if column has NULL value do not transform it with templates

Pitfalls:
if NULL value has whitespace before it will not be null, but it will be correct quoted string. But it is parser issue.