### PR TITLE
feat. Allow to specify arguments for commands value.

### DIFF
--- a/modules/filters/relfilter/filter.go
+++ b/modules/filters/relfilter/filter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os/exec"
 	"regexp"
+	"strings"
 
 	"github.com/nixys/nxs-data-anonymizer/misc"
 )
@@ -591,7 +592,10 @@ func execFilter(f execFilterOpts, td any, tde []string) (v []byte, err error) {
 
 		var stderr, stdout bytes.Buffer
 
-		cmd := exec.Command(f.v)
+		parsed_cmd := strings.Split(f.v, " ")
+		name := parsed_cmd[0]
+		args := parsed_cmd[1:]
+		cmd := exec.Command(name, args...)
 
 		cmd.Stdout = &stdout
 		cmd.Stderr = &stderr


### PR DESCRIPTION
The basic use of the custom script in yml conf is to specify the path to the executable with a shebang string
`value: '/path/to/script'.` If you try to pass something like `"/bin/python /path/to/script.py"`, it will fail, because `exec.Command()` when get an argument, treats it as a command name to do. This changes split command from the yml config by spaces. The new first string is is a command name, and the others are args.
If you want to do some bash thing with piping, it's better to pass the value like this `"bash -c date | awk '{print $2}'"`