### PR TITLE
Distinguish between empty value and null

### DIFF
--- a/modules/anonymizers/pgsql/.testdata/pgsql_test.in.sql
+++ b/modules/anonymizers/pgsql/.testdata/pgsql_test.in.sql
@@ -84,6 +84,18 @@ CREATE TABLE public.list_types3 (
 ALTER TABLE public.list_types3 OWNER TO postgres;
 
 --
+-- Name: list_types_not_null; Type: TABLE; Schema: public; Owner: postgres
+--
+CREATE TABLE public.list_types_not_null (
+                                   varchar_type character varying NOT NULL,
+                                   text_type text NOT NULL,
+                                   id bigint NOT NULL
+);
+
+
+ALTER TABLE public.list_types_not_null OWNER TO postgres;
+
+--
 -- Name: list_types_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
 --
 
@@ -154,6 +166,15 @@ COPY public.list_types3 (integer_type, numeric_type, double_precision_type, varc
 8767542	\N	5.08081291	\N	Fames ac turpis egestas maecenas. Volutpat lacus laoreet non curabitur gravida arcu ac tortor. Sit amet commodo nulla facilisi nullam vehicula. Ipsum dolor sit amet consectetur adipiscing elit pellentesque. Maecenas ultricies mi eget mauris pharetra. Sed faucibus turpis in eu mi bibendum. Massa ultricies mi quis hendrerit dolor magna. Non diam phasellus vestibulum lorem sed. Vestibulum mattis ullamcorper velit sed ullamcorper morbi tincidunt ornare massa. Massa ultricies mi quis hendrerit dolor magna eget est lorem. Quam elementum pulvinar etiam non quam lacus suspendisse faucibus.	2058-03-29	\N	f	<root>\n  <invented>concerned</invented>\n  <feet>-1671936329.7007055</feet>\n  <win>slept</win>\n  <until>how</until>\n  <lion>-1838021068</lion>\n</root>	{"basis": "mine", "company": {"tired": false, "prevent": false, "suppose": 735075799}, "worried": {"iron": 378563223.91183805, "nest": false, "raise": {"date": false, "engineer": true, "television": 136840736.65782642}}}	7
 \.
 
+
+--
+-- Data for Name: list_types_not_null; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+COPY public.list_types_not_null (varchar_type, text_type, id) FROM stdin;
+biba	Lorem ipsum	0
+	Lorem ipsum lorem ipsum	1
+boba		2
+\.
 
 --
 -- Name: list_types_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres

--- a/modules/anonymizers/pgsql/.testdata/pgsql_test.out.sql
+++ b/modules/anonymizers/pgsql/.testdata/pgsql_test.out.sql
@@ -84,6 +84,18 @@ CREATE TABLE public.list_types3 (
 ALTER TABLE public.list_types3 OWNER TO postgres;
 
 --
+-- Name: list_types_not_null; Type: TABLE; Schema: public; Owner: postgres
+--
+CREATE TABLE public.list_types_not_null (
+                                   varchar_type character varying NOT NULL,
+                                   text_type text NOT NULL,
+                                   id bigint NOT NULL
+);
+
+
+ALTER TABLE public.list_types_not_null OWNER TO postgres;
+
+--
 -- Name: list_types_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
 --
 
@@ -147,6 +159,15 @@ COPY public.list_types3 (integer_type, numeric_type, double_precision_type, varc
 8767542	\N	5.08081291	\N	Fames ac turpis egestas maecenas. Volutpat lacus laoreet non curabitur gravida arcu ac tortor. Sit amet commodo nulla facilisi nullam vehicula. Ipsum dolor sit amet consectetur adipiscing elit pellentesque. Maecenas ultricies mi eget mauris pharetra. Sed faucibus turpis in eu mi bibendum. Massa ultricies mi quis hendrerit dolor magna. Non diam phasellus vestibulum lorem sed. Vestibulum mattis ullamcorper velit sed ullamcorper morbi tincidunt ornare massa. Massa ultricies mi quis hendrerit dolor magna eget est lorem. Quam elementum pulvinar etiam non quam lacus suspendisse faucibus.	2058-03-29	\N	f	<root>\n  <invented>concerned</invented>\n  <feet>-1671936329.7007055</feet>\n  <win>slept</win>\n  <until>how</until>\n  <lion>-1838021068</lion>\n</root>	{"basis": "mine", "company": {"tired": false, "prevent": false, "suppose": 735075799}, "worried": {"iron": 378563223.91183805, "nest": false, "raise": {"date": false, "engineer": true, "television": 136840736.65782642}}}	7
 \.
 
+
+--
+-- Data for Name: list_types_not_null; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+COPY public.list_types_not_null (varchar_type, text_type, id) FROM stdin;
+biba	Lorem ipsum	0
+\N	Lorem ipsum lorem ipsum	1
+boba	\N	2
+\.
 
 --
 -- Name: list_types_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres


### PR DESCRIPTION
This pull request addresses the issue where an empty string value in a column is treated incorrectly.

Sprig does not differentiate between an empty string and NULL, which leads to errors when restoring anonymized tables back into the database.

A test case has been added to demonstrate the problem.

    Without the patch: Empty strings are replaced with \N.
    With the patch: Values remain as expected.

